### PR TITLE
mask api key

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -76,7 +76,7 @@
     
     <div class="input-group">
       <label for="apiKeyInput">Gemini API Key:</label>
-      <input type="text" id="apiKeyInput" placeholder="Enter your Gemini API key">
+      <input type="password" id="apiKeyInput" placeholder="Enter your Gemini API key">
     </div>
     
     <button id="saveApiKeyButton">Save API Key</button>


### PR DESCRIPTION
I think API key should be masked instead of show, and be treated like a password so attackers don't access your api key elsewhere.